### PR TITLE
Fixed miri warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/anza-xyz/pinocchio"
-rust-version = "1.80"
+rust-version = "1.84"
 
 [workspace.dependencies]
 five8_const = "0.1.4"

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -199,7 +199,7 @@ macro_rules! align_pointer {
     ($ptr:ident) => {
         // integer-to-pointer cast: the resulting pointer will have the same provenance as
         // the original pointer and it follows the alignment requirement for the input.
-        (($ptr as usize + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1)) as *mut u8
+        $ptr.map_addr(|ptr| ((ptr as usize + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1)))
     };
 }
 


### PR DESCRIPTION
Swaps to the new functions that are for the [Strict Provenance API](https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance).